### PR TITLE
apb_timer.sv: Fix prescaler behavior

### DIFF
--- a/src/timer.sv
+++ b/src/timer.sv
@@ -59,7 +59,7 @@ module timer
             irq_o[0] = 1'b1;
 
         // compare match irq if compare reg ist set
-        if (regs_q[`REG_CMP] != 'b0 && regs_q[`REG_TIMER] == regs_q[`REG_CMP])
+        if (regs_q[`REG_CMP] != 'b0 && regs_q[`REG_TIMER] == regs_q[`REG_CMP] && prescaler_int == cycle_counter_q)
             irq_o[1] = 1'b1;
 
     end

--- a/src/timer.sv
+++ b/src/timer.sv
@@ -55,7 +55,7 @@ module timer
         irq_o = 2'b0;
 
         // overlow irq
-        if (regs_q[`REG_TIMER] == 32'hffff_ffff)
+        if (regs_q[`REG_TIMER] == 32'hffff_ffff && prescaler_int == cycle_counter_q)
             irq_o[0] = 1'b1;
 
         // compare match irq if compare reg ist set

--- a/src/timer.sv
+++ b/src/timer.sv
@@ -82,7 +82,7 @@ module timer
             regs_n[`REG_TIMER] = regs_q[`REG_TIMER] + 1;
 
         // reset prescaler cycle counter
-        if (cycle_counter_q >= regs_q[`REG_TIMER_CTRL])
+        if (cycle_counter_q >= prescaler_int)
             cycle_counter_n = 32'b0;
 
         // written from APB bus - gets priority


### PR DESCRIPTION
Fixes related to the use of prescaler:

- The cycle counter needs to be reset with prescaler_int and not the complete  regs_q[`REG_TIMER_CTRL]

- Overflow and CMP interrupts should be set at the last cycle count of the prescaler when the condition is met in order to maintain proper timing.